### PR TITLE
added new es3 flag for trailing commas

### DIFF
--- a/closure_linter/ecmalintrules.py
+++ b/closure_linter/ecmalintrules.py
@@ -350,10 +350,10 @@ class EcmaScriptLintRules(checkerbase.LintRulesBase):
 
       if FLAGS.check_trailing_comma:
         if last_code.IsOperator(','):
-            self._HandleError(
-                errors.COMMA_AT_END_OF_LITERAL,
-                'Illegal comma at end of object literal', last_code,
-                position=Position.All(last_code.string))
+          self._HandleError(
+              errors.COMMA_AT_END_OF_LITERAL,
+              'Illegal comma at end of object literal', last_code,
+              position=Position.All(last_code.string))
 
       if state.InFunction() and state.IsFunctionClose():
         if state.InTopLevelFunction():
@@ -464,10 +464,10 @@ class EcmaScriptLintRules(checkerbase.LintRulesBase):
       last_code = token.metadata.last_code
       if FLAGS.check_trailing_comma and token_type == Type.END_BRACKET:
         if last_code.IsOperator(','):
-            self._HandleError(
-                errors.COMMA_AT_END_OF_LITERAL,
-                'Illegal comma at end of array literal', last_code,
-                position=Position.All(last_code.string))
+          self._HandleError(
+              errors.COMMA_AT_END_OF_LITERAL,
+              'Illegal comma at end of array literal', last_code,
+              position=Position.All(last_code.string))
 
       if (token.previous and token.previous.type == Type.WHITESPACE and
           not token.previous.IsFirstInLine() and

--- a/closure_linter/ecmalintrules.py
+++ b/closure_linter/ecmalintrules.py
@@ -46,6 +46,9 @@ flags.DEFINE_list('custom_jsdoc_tags', '', 'Extra jsdoc tags to allow')
 flags.DEFINE_boolean('dot_on_next_line', False, 'Require dots to be'
                      'placed on the next line for wrapped expressions')
 
+flags.DEFINE_boolean('es3', False, 'Check trailing commas'
+                     ' (not needed from ES5 onwards)')
+
 # TODO(robbyw): Check for extra parens on return statements
 # TODO(robbyw): Check for 0px in strings
 # TODO(robbyw): Ensure inline jsDoc is in {}
@@ -344,6 +347,14 @@ class EcmaScriptLintRules(checkerbase.LintRulesBase):
 
     elif token_type == Type.END_BLOCK:
       last_code = token.metadata.last_code
+
+      if FLAGS.es3:
+        if last_code.IsOperator(','):
+            self._HandleError(
+                errors.COMMA_AT_END_OF_LITERAL,
+                'Illegal comma at end of object literal', last_code,
+                position=Position.All(last_code.string))
+
       if state.InFunction() and state.IsFunctionClose():
         if state.InTopLevelFunction():
           # A semicolons should not be included at the end of a function
@@ -449,6 +460,15 @@ class EcmaScriptLintRules(checkerbase.LintRulesBase):
       # Ensure there is no space before closing parentheses, except when
       # it's in a for statement with an omitted section, or when it's at the
       # beginning of a line.
+
+      last_code = token.metadata.last_code
+      if FLAGS.es3 and token_type == Type.END_BRACKET:
+        if last_code.IsOperator(','):
+            self._HandleError(
+                errors.COMMA_AT_END_OF_LITERAL,
+                'Illegal comma at end of array literal', last_code,
+                position=Position.All(last_code.string))
+
       if (token.previous and token.previous.type == Type.WHITESPACE and
           not token.previous.IsFirstInLine() and
           not (last_non_space_token and last_non_space_token.line_number ==

--- a/closure_linter/ecmalintrules.py
+++ b/closure_linter/ecmalintrules.py
@@ -46,8 +46,8 @@ flags.DEFINE_list('custom_jsdoc_tags', '', 'Extra jsdoc tags to allow')
 flags.DEFINE_boolean('dot_on_next_line', False, 'Require dots to be'
                      'placed on the next line for wrapped expressions')
 
-flags.DEFINE_boolean('es3', False, 'Check trailing commas'
-                     ' (not needed from ES5 onwards)')
+flags.DEFINE_boolean('check_trailing_comma', False, 'Check trailing commas'
+                     ' (ES3, not needed from ES5 onwards)')
 
 # TODO(robbyw): Check for extra parens on return statements
 # TODO(robbyw): Check for 0px in strings
@@ -348,7 +348,7 @@ class EcmaScriptLintRules(checkerbase.LintRulesBase):
     elif token_type == Type.END_BLOCK:
       last_code = token.metadata.last_code
 
-      if FLAGS.es3:
+      if FLAGS.check_trailing_comma:
         if last_code.IsOperator(','):
             self._HandleError(
                 errors.COMMA_AT_END_OF_LITERAL,
@@ -462,7 +462,7 @@ class EcmaScriptLintRules(checkerbase.LintRulesBase):
       # beginning of a line.
 
       last_code = token.metadata.last_code
-      if FLAGS.es3 and token_type == Type.END_BRACKET:
+      if FLAGS.check_trailing_comma and token_type == Type.END_BRACKET:
         if last_code.IsOperator(','):
             self._HandleError(
                 errors.COMMA_AT_END_OF_LITERAL,

--- a/closure_linter/es3_test.py
+++ b/closure_linter/es3_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# Copyright 2013 The Closure Linter Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for trailing commas (ES3) errors
+
+"""
+
+
+import gflags as flags
+import unittest as googletest
+
+from closure_linter import errors
+from closure_linter import runner
+from closure_linter.common import erroraccumulator
+
+flags.FLAGS.es3 = True
+class ES3Test(googletest.TestCase):
+  """Test case to for gjslint errorrules."""
+
+  def testGetTrailingCommaArray(self):
+    """ warning for trailing commas before closing array
+    """
+    original = ['q = [1,]', ]
+
+    # Expect line too long.
+    expected = errors.COMMA_AT_END_OF_LITERAL
+
+    self._AssertInError(original, expected)
+
+  def testGetTrailingCommaDict(self):
+    """ warning for trailing commas before closing array
+    """
+    original = ['q = {1:1,}', ]
+
+    # Expect line too long.
+    expected = errors.COMMA_AT_END_OF_LITERAL
+
+    self._AssertInError(original, expected)
+
+  def _AssertInError(self, original, expected):
+    """Asserts that the error fixer corrects original to expected."""
+
+    # Trap gjslint's output parse it to get messages added.
+    error_accumulator = erroraccumulator.ErrorAccumulator()
+    runner.Run('testing.js', error_accumulator, source=original)
+    error_nums = [e.code for e in error_accumulator.GetErrors()]
+
+    self.assertIn(expected, error_nums)
+
+if __name__ == '__main__':
+  googletest.main()

--- a/closure_linter/trailing_comma_test.py
+++ b/closure_linter/trailing_comma_test.py
@@ -26,8 +26,8 @@ from closure_linter import errors
 from closure_linter import runner
 from closure_linter.common import erroraccumulator
 
-flags.FLAGS.es3 = True
-class ES3Test(googletest.TestCase):
+flags.FLAGS.check_trailing_comma = True
+class TrailingCommaTest(googletest.TestCase):
   """Test case to for gjslint errorrules."""
 
   def testGetTrailingCommaArray(self):


### PR DESCRIPTION
Adds a -es3 flag that enables again trailing commas errors, equivalent to the jshint one.