### PR TITLE
Added recognition of template strings.

### DIFF
--- a/closure_linter/ecmametadatapass.py
+++ b/closure_linter/ecmametadatapass.py
@@ -502,7 +502,8 @@ class EcmaMetaDataPass(object):
       is_end_of_block = (
           token.type == TokenType.END_BLOCK and
           token.metadata.context.type != EcmaContext.OBJECT_LITERAL)
-      is_multiline_string = token.type == TokenType.STRING_TEXT
+      is_multiline_string = (token.type == TokenType.STRING_TEXT or
+                             token.type == TokenType.TEMPLATE_STRING_START)
       is_continued_var_decl = (token.IsKeyword('var') and
                                next_code and
                                (next_code.type in [TokenType.IDENTIFIER,

--- a/closure_linter/javascripttokenizer.py
+++ b/closure_linter/javascripttokenizer.py
@@ -36,6 +36,7 @@ class JavaScriptModes(object):
   TEXT_MODE = 'text'
   SINGLE_QUOTE_STRING_MODE = 'single_quote_string'
   DOUBLE_QUOTE_STRING_MODE = 'double_quote_string'
+  TEMPLATE_STRING_MODE = 'template_string'
   BLOCK_COMMENT_MODE = 'block_comment'
   DOC_COMMENT_MODE = 'doc_comment'
   DOC_COMMENT_LEX_SPACES_MODE = 'doc_comment_spaces'
@@ -75,6 +76,10 @@ class JavaScriptTokenizer(tokenizer.Tokenizer):
   SINGLE_QUOTE_TEXT = re.compile(r"([^'\\]|\\(.|$))+")
   DOUBLE_QUOTE = re.compile(r'"')
   DOUBLE_QUOTE_TEXT = re.compile(r'([^"\\]|\\(.|$))+')
+  # Template strings are different from normal strings in that they do not
+  # require escaping of end of lines in order to be multi-line.
+  TEMPLATE_QUOTE = re.compile(r'`')
+  TEMPLATE_QUOTE_TEXT = re.compile(r'([^`]|$)+')
 
   START_SINGLE_LINE_COMMENT = re.compile(r'//')
   END_OF_LINE_SINGLE_LINE_COMMENT = re.compile(r'//$')
@@ -342,6 +347,8 @@ class JavaScriptTokenizer(tokenizer.Tokenizer):
                     JavaScriptModes.SINGLE_QUOTE_STRING_MODE),
             Matcher(cls.DOUBLE_QUOTE, Type.DOUBLE_QUOTE_STRING_START,
                     JavaScriptModes.DOUBLE_QUOTE_STRING_MODE),
+            Matcher(cls.TEMPLATE_QUOTE, Type.TEMPLATE_STRING_START,
+                    JavaScriptModes.TEMPLATE_STRING_MODE),
             Matcher(cls.REGEX, Type.REGEX),
 
             # Next we check for start blocks appearing outside any of the items
@@ -389,6 +396,12 @@ class JavaScriptTokenizer(tokenizer.Tokenizer):
         JavaScriptModes.DOUBLE_QUOTE_STRING_MODE: [
             Matcher(cls.DOUBLE_QUOTE_TEXT, Type.STRING_TEXT),
             Matcher(cls.DOUBLE_QUOTE, Type.DOUBLE_QUOTE_STRING_END,
+                    JavaScriptModes.TEXT_MODE)],
+
+        # Matchers for template strings.
+        JavaScriptModes.TEMPLATE_STRING_MODE: [
+            Matcher(cls.TEMPLATE_QUOTE_TEXT, Type.STRING_TEXT),
+            Matcher(cls.TEMPLATE_QUOTE, Type.TEMPLATE_STRING_END,
                     JavaScriptModes.TEXT_MODE)],
 
         # Matchers for block comments.

--- a/closure_linter/javascripttokens.py
+++ b/closure_linter/javascripttokens.py
@@ -34,6 +34,8 @@ class JavaScriptTokenType(tokens.TokenType):
   SINGLE_QUOTE_STRING_END = "string'"
   DOUBLE_QUOTE_STRING_START = '"string'
   DOUBLE_QUOTE_STRING_END = 'string"'
+  TEMPLATE_STRING_START = '`string'
+  TEMPLATE_STRING_END = 'string`'
   STRING_TEXT = 'string'
   START_BLOCK = '{'
   END_BLOCK = '}'
@@ -63,7 +65,8 @@ class JavaScriptTokenType(tokens.TokenType):
 
   STRING_TYPES = frozenset([
       SINGLE_QUOTE_STRING_START, SINGLE_QUOTE_STRING_END,
-      DOUBLE_QUOTE_STRING_START, DOUBLE_QUOTE_STRING_END, STRING_TEXT])
+      DOUBLE_QUOTE_STRING_START, DOUBLE_QUOTE_STRING_END,
+      TEMPLATE_STRING_START, TEMPLATE_STRING_END, STRING_TEXT])
 
   COMMENT_TYPES = frozenset([
       START_SINGLE_LINE_COMMENT, COMMENT,
@@ -92,7 +95,8 @@ class JavaScriptTokenType(tokens.TokenType):
   # x.y or [1, 2], or (10 + 9) or {a: 10}.
   EXPRESSION_ENDER_TYPES = [tokens.TokenType.NORMAL, IDENTIFIER, NUMBER,
                             SIMPLE_LVALUE, END_BRACKET, END_PAREN, END_BLOCK,
-                            SINGLE_QUOTE_STRING_END, DOUBLE_QUOTE_STRING_END]
+                            SINGLE_QUOTE_STRING_END, DOUBLE_QUOTE_STRING_END,
+                            TEMPLATE_STRING_END]
 
 
 class JavaScriptToken(tokens.Token):

--- a/closure_linter/statetracker.py
+++ b/closure_linter/statetracker.py
@@ -1265,7 +1265,8 @@ class StateTracker(object):
     if type == Type.SEMICOLON or type == Type.END_PAREN or (
         type == Type.END_BRACKET and
         self._last_non_space_token.type not in (
-            Type.SINGLE_QUOTE_STRING_END, Type.DOUBLE_QUOTE_STRING_END)):
+            Type.SINGLE_QUOTE_STRING_END, Type.DOUBLE_QUOTE_STRING_END,
+            Type.TEMPLATE_STRING_END)):
       # We end on any numeric array index, but keep going for string based
       # array indices so that we pick up manually exported identifiers.
       self._doc_comment = None

--- a/closure_linter/testdata/tokenizer.js
+++ b/closure_linter/testdata/tokenizer.js
@@ -18,6 +18,12 @@
  * @author robbyw@google.com (Robby Walker)
  */
 
+// Regression test: if we do not recognize template strings, this will fail.
+var templateString = String.raw`
+  easy
+  multiline,
+  too!`;
+
 // Regression test: if regular expressions parse incorrectly this will emit an
 // error such as: Missing space after '/'
 x = /[^\']/;  // and all the other chars

--- a/closure_linter/tokenutil.py
+++ b/closure_linter/tokenutil.py
@@ -678,7 +678,8 @@ def GetStringAfterToken(token):
   """
   string_token = SearchUntil(token, JavaScriptTokenType.STRING_TEXT,
                              [JavaScriptTokenType.SINGLE_QUOTE_STRING_END,
-                              JavaScriptTokenType.DOUBLE_QUOTE_STRING_END])
+                              JavaScriptTokenType.DOUBLE_QUOTE_STRING_END,
+                              JavaScriptTokenType.TEMPLATE_STRING_END])
   if string_token:
     return string_token.string
   else:


### PR DESCRIPTION
Hi,

As I was working on some changes in Chromium, I kept being tripped by the presubmit complaining about a missing semicolon at the end of line in a [template string](https://cs.chromium.org/chromium/src/chrome/browser/resources/chromeos/login/oobe_screen_oauth_enrollment.js?rcl=0&l=7). 

Chromium uses gjslint, so I thought I would give a try at adding recognition of these strings so that the Chromium presubmits eventually stop complaining about valid code. This is my attempt at doing so.

Cheers,
YA
